### PR TITLE
Fix for invalid search

### DIFF
--- a/clickable-tags/__init__.py
+++ b/clickable-tags/__init__.py
@@ -28,7 +28,7 @@ def linkHandler(self, url, _old):
     if url.startswith('ct_click_'):
         tag = url.replace('ct_click_', '')
         browser = dialogs.open('Browser', self.mw)
-        browser.setFilter('\'tag:%s\'' % tag) #Quotes around tag should allow for spaces in tag name
+        browser.setFilter('\"tag:%s\"' % tag) #Quotes around tag should allow for spaces in tag name
     elif url.startswith('ct_dblclick_'):
         tag, deck = url.replace('ct_dblclick_', '').split('|')
         browser = dialogs.open('Browser', self.mw)

--- a/clickable-tags/__init__.py
+++ b/clickable-tags/__init__.py
@@ -28,7 +28,7 @@ def linkHandler(self, url, _old):
     if url.startswith('ct_click_'):
         tag = url.replace('ct_click_', '')
         browser = dialogs.open('Browser', self.mw)
-        browser.setFilter('tag:%s' % tag)
+        browser.setFilter('\'tag:%s\'' % tag) #Quotes around tag should allow for spaces in tag name
     elif url.startswith('ct_dblclick_'):
         tag, deck = url.replace('ct_dblclick_', '').split('|')
         browser = dialogs.open('Browser', self.mw)

--- a/clickable-tags/__init__.py
+++ b/clickable-tags/__init__.py
@@ -28,11 +28,11 @@ def linkHandler(self, url, _old):
     if url.startswith('ct_click_'):
         tag = url.replace('ct_click_', '')
         browser = dialogs.open('Browser', self.mw)
-        browser.setFilter('\"tag:%s\"' % tag) #Quotes around tag should allow for spaces in tag name
+        browser.setFilter('"tag:%s"' % tag)
     elif url.startswith('ct_dblclick_'):
         tag, deck = url.replace('ct_dblclick_', '').split('|')
         browser = dialogs.open('Browser', self.mw)
-        browser.setFilter('tag:%s "deck:%s"' % (tag, deck))
+        browser.setFilter('"tag:%s" "deck:%s"' % (tag, deck))
         browser.setWindowState(
             browser.windowState() & ~Qt.WindowMinimized | Qt.WindowActive
         )


### PR DESCRIPTION
Adding quotes around tag field and name allows for more robust searching within Anki. This has been tested on my own system (MacOS running Anki 2.1.15) and works.